### PR TITLE
include cmake_modules as catkin depencency to allow for find_package(Eigen)

### DIFF
--- a/internal_space_spline_trajectory_action/CMakeLists.txt
+++ b/internal_space_spline_trajectory_action/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(internal_space_spline_trajectory_action)
 
-find_package(catkin REQUIRED COMPONENTS rtt_ros trajectory_msgs control_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules rtt_ros trajectory_msgs control_msgs)
 
 find_package(OROCOS-RTT REQUIRED)
 find_package(Eigen REQUIRED)

--- a/internal_space_spline_trajectory_action/package.xml
+++ b/internal_space_spline_trajectory_action/package.xml
@@ -12,6 +12,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
   <build_depend>rtt</build_depend>
   <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_rosclock</build_depend>

--- a/internal_space_spline_trajectory_generator/CMakeLists.txt
+++ b/internal_space_spline_trajectory_generator/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(internal_space_spline_trajectory_generator)
 
-find_package(catkin REQUIRED COMPONENTS rtt_ros trajectory_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules rtt_ros trajectory_msgs)
 
 find_package(OROCOS-RTT REQUIRED)
 find_package(Eigen REQUIRED)

--- a/internal_space_spline_trajectory_generator/package.xml
+++ b/internal_space_spline_trajectory_generator/package.xml
@@ -12,6 +12,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
   <build_depend>rtt</build_depend>
   <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_rosclock</build_depend>

--- a/oro_joint_state_publisher/CMakeLists.txt
+++ b/oro_joint_state_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(oro_joint_state_publisher)
 
-find_package(catkin REQUIRED COMPONENTS rtt_ros sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules rtt_ros sensor_msgs)
 
 find_package(Eigen REQUIRED)
 

--- a/oro_joint_state_publisher/package.xml
+++ b/oro_joint_state_publisher/package.xml
@@ -12,6 +12,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
   <build_depend>rtt</build_depend>
   <build_depend>rtt_ros</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
This commit for indigo-devel fixes some migration issues, causing find_package(Eigen) to fail on indigo
see: http://wiki.ros.org/indigo/Migration#cmake_modules

Please note, this intended for an indigo-devel branch. Probably it is incompatible to hydro.